### PR TITLE
(Proposal) Changes by am/pm marker

### DIFF
--- a/src/main/java/com/github/fedy2/weather/binding/adapter/RFC822DateAdapter.java
+++ b/src/main/java/com/github/fedy2/weather/binding/adapter/RFC822DateAdapter.java
@@ -25,8 +25,8 @@ public class RFC822DateAdapter extends XmlAdapter<String, Date> {
             new SimpleDateFormat("d MMM yy HH:mm:ss z", Locale.US),
             new SimpleDateFormat("d MMM yyyy HH:mm z", Locale.US),
             new SimpleDateFormat("d MMM yyyy HH:mm:ss z", Locale.US),
-            //exception to RFC 822 format used by Yahoo "Thu, 22 Dec 2011 1:50 pm CET"
-            new SimpleDateFormat("EEE, d MMM yyyy HH:mm a z", Locale.US)};
+            //exception to RFC 822 format used by Yahoo "Thu, 22 Dec 2011 01:50 pm CET"
+            new SimpleDateFormat("EEE, d MMM yyyy hh:mm a z", Locale.US)};
 
 	private Logger logger = LoggerFactory.getLogger(RFC822DateAdapter.class);
 


### PR DESCRIPTION
by am/pm marker, "a"
hour in day (00-23), "HH"  should be changed to   
hour in am/pm (01-12), "hh" 


as-is parsing
----------------
Wed, 04 May 2016 03:00 PM KST ---(parse)---> Wed May 04 03:00:00 KST 2016   (wrong)

to-be parsing
----------------
Wed, 04 May 2016 03:00 PM KST ---(parse)---> Wed May 04 15:00:00 KST 2016   (correct)


thank you!